### PR TITLE
first attempt at a fix, override getData()

### DIFF
--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -79,6 +79,10 @@ date.prototype.format = function (item, format) {
 	}
 };
 
+date.prototype.getData = function (item) {
+	var value = item.get(this.path);
+	return moment.utc(value).format('YYYY-MM-DD');
+}
 /**
  * Returns a new `moment` object with the field value
  */
@@ -93,13 +97,13 @@ date.prototype.moment = function (item) {
  * either the provided input format or the default for the field
  */
 date.prototype.parse = function (value, format, strict) {
-	var m = this.isUTC ? moment.utc : moment;
+	var m = moment.utc;
 	// TODO Check should maybe be if (typeof value === 'string')
 	// use the parseFormatString. Ever relevant?
 	if (typeof value === 'number' || value instanceof Date) {
 		return m(value);
 	} else {
-		return m(value, format || this.parseFormatString, strict);
+		return m(value);
 	}
 };
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

